### PR TITLE
Make git clone task optional in cloud-config

### DIFF
--- a/cloud-config.sample
+++ b/cloud-config.sample
@@ -49,7 +49,7 @@ coreos:
       [Service]
       ExecStartPre=-/usr/bin/docker kill 2048
       ExecStartPre=-/usr/bin/docker rm 2048
-      ExecStartPre=/usr/bin/git clone https://github.com/trizko/2048.git /home/core/share
+      ExecStartPre=-/usr/bin/git clone https://github.com/trizko/2048.git /home/core/share
       ExecStartPre=/usr/bin/docker build -t trizko/2048 /home/core/share/
       ExecStart=/usr/bin/docker run --name 2048 -p 8080:8080 trizko/2048
       ExecStop=/usr/bin/rm -rf /home/core/share


### PR DESCRIPTION
This is so that we can run this machine from our local machine without cloning the repo from github and instead using our local changes
